### PR TITLE
fix: remove stray console.log from snapToNetwork

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ function snapToNetwork(point) {
 
     var nearestVertexDist = null,
         nearestCoord = null;
-    console.log(nearestLineIndex)
     turfMeta.coordEach(marnet.features[nearestLineIndex], function (currentCoord) {
 
         let distToVertex = rhumbDistance(point, currentCoord);


### PR DESCRIPTION
## Summary

- Removes a stray `console.log(nearestLineIndex)` left in `snapToNetwork` since the initial commit.
- Every call to `searoute()` was logging the index of the nearest marnet feature to stdout, with no opt-out for consumers.

## Why

Pure noise — debug output from initial development. No behavior change beyond removing the side effect.

## Test plan

- [ ] `require('searoute-js')` and call with sample origin/destination — confirm no stdout output.