### PR TITLE
feat: return origin/destination snap distance on route properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ var route = searoute(origin, destination);
 // Defaults to nautical miles, can be degrees, radians, miles, or kilometers.
 var routeMiles = searoute(origin, destination, "miles");
 
+// The returned LineString's `properties` includes:
+//   - units: the units used for length and snap-distance values
+//   - length: total route length in the specified units
+//   - originSnapDistance: distance from the input origin to where the route actually starts
+//     (the input is snapped to the nearest point on the maritime network)
+//   - destinationSnapDistance: distance from the input destination to where the route actually ends
+//
+// `originSnapDistance` and `destinationSnapDistance` are useful for telling whether an input
+// point was on or near the sea — small values mean a clean snap, large values usually mean
+// the input was inland.
+
 
 ~~~
 

--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ module.exports = function searoute(origin, destination, units = 'nm') {
 
         let firstRoutePoint = route.path[0];
         let lastRoutePoint = route.path[route.path.length - 1];
-        lineString.properties.originSnapDistance = distanceInUnits(origin.geometry.coordinates, firstRoutePoint, units);
-        lineString.properties.destinationSnapDistance = distanceInUnits(destination.geometry.coordinates, lastRoutePoint, units);
+        lineString.properties.originSnapDistance = distanceInUnits(getCoord(origin), firstRoutePoint, units);
+        lineString.properties.destinationSnapDistance = distanceInUnits(getCoord(destination), lastRoutePoint, units);
 
         return lineString;
     } catch (err) {
@@ -76,4 +76,8 @@ function distanceInUnits(fromCoord, toCoord, units) {
     return units == 'nm'
         ? length(line, { units: 'miles' }) * 1.15078
         : length(line, { units: units });
+}
+
+function getCoord(input) {
+    return input.geometry ? input.geometry.coordinates : input.coordinates;
 }

--- a/index.js
+++ b/index.js
@@ -28,6 +28,11 @@ module.exports = function searoute(origin, destination, units = 'nm') {
             ? length(lineString, { units: 'miles' }) * 1.15078
             : length(lineString, { units: units });
 
+        let firstRoutePoint = route.path[0];
+        let lastRoutePoint = route.path[route.path.length - 1];
+        lineString.properties.originSnapDistance = distanceInUnits(origin.geometry.coordinates, firstRoutePoint, units);
+        lineString.properties.destinationSnapDistance = distanceInUnits(destination.geometry.coordinates, lastRoutePoint, units);
+
         return lineString;
     } catch (err) {
         throw err;
@@ -64,4 +69,11 @@ function snapToNetwork(point) {
     });
 
     return turfHelpers.point(nearestCoord);
+}
+
+function distanceInUnits(fromCoord, toCoord, units) {
+    let line = turfHelpers.lineString([fromCoord, toCoord]);
+    return units == 'nm'
+        ? length(line, { units: 'miles' }) * 1.15078
+        : length(line, { units: units });
 }


### PR DESCRIPTION
Closes #12.

## Summary

- Adds `originSnapDistance` and `destinationSnapDistance` to the returned LineString's `properties`, reported in the same `units` as the route length.
- Useful for callers to know whether an input point was already on the maritime network or required snapping (and by how much).

## Why

When an input point is inland or off-network, the library snaps it silently to the nearest network point. Until now, callers had no signal about this — they had to recompute it themselves against the route's first/last waypoint. Requested by @dkremsa in #12, who was already doing exactly this with a local haversine.

## Implementation

- New helper `distanceInUnits(fromCoord, toCoord, units)` that mirrors the existing length-in-units pattern in the file, including the `nm` special case.
- Two new lines in the main flow attach the values to `lineString.properties`.

## Test plan

Manual smoke tests against three cases (sea→sea / inland→sea / unit conversions). Sample output:

- README sea-to-sea (nm): `originSnapDistance ≈ 228 nm`, `destinationSnapDistance ≈ 115 nm`
- Inland Denver → UK Solent (km): `originSnapDistance ≈ 1260 km` (distance to coast), `destinationSnapDistance ≈ 2.8 km` (clean snap to network)
- Same in miles: `783 mi` and `1.74 mi` — conversion checks out

- [ ] Smoke test confirms new properties present with correct units
- [ ] Conversion between km/miles/nm is consistent with the existing `length` property